### PR TITLE
fix: remove non-existant `uglify-package`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "bundleDependencies": [
     "@remy/snyk-shrink-test",
-    "uglify-package",
     "@remy/vuln-test",
     "semver-rs-demo"
   ],


### PR DESCRIPTION
it fails `npm install` for `npm 5.6.0` on Travis